### PR TITLE
Expose TSKPinningValidator init routine and properties

### DIFF
--- a/TrustKit/TSKPinningValidator_Private.h
+++ b/TrustKit/TSKPinningValidator_Private.h
@@ -11,28 +11,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/* Methods that are internal to TrustKit */
-@interface TSKPinningValidator (Internal)
-
-/**
- Initialize an instance of TSKPinningValidator.
- 
- @param domainPinningPolicies A dictionnary of domains and the corresponding pinning policy.
- @param hashCache The hash cache to use. If nil, no caching is performed, performance may suffer.
- @param ignorePinsForUserTrustAnchors Set to true to ignore the trust anchors in the user trust store
- @param validationCallbackQueue The queue used when invoking the validationResultHandler
- @param validationCallback The callback invoked with validation results
- @return Initialized instance
- */
-- (instancetype _Nullable)initWithDomainPinningPolicies:(NSDictionary<NSString *, TKSDomainPinningPolicy *> *)domainPinningPolicies
-                                              hashCache:(TSKSPKIHashCache *)hashCache
-                          ignorePinsForUserTrustAnchors:(BOOL)ignorePinsForUserTrustAnchors
-                                validationCallbackQueue:(dispatch_queue_t)validationCallbackQueue
-                                     validationCallback:(TSKPinningValidatorCallback)validationCallback;
-
-@end
-
-
 @interface TSKPinningValidatorResult (Internal)
 
 - (instancetype _Nullable)initWithServerHostname:(NSString *)serverHostname

--- a/TrustKit/parse_configuration.m
+++ b/TrustKit/parse_configuration.m
@@ -20,7 +20,7 @@ NSDictionary *parseTrustKitConfiguration(NSDictionary *trustKitArguments)
 {
     // Convert settings supplied by the user to a configuration dictionary that can be used by TrustKit
     // This includes checking the sanity of the settings and converting public key hashes/pins from an
-    // NSSArray of NSStrings (as provided by the user) to an NSSet of NSData (as needed by TrustKit)
+    // NSArray of NSStrings (as provided by the user) to an NSSet of NSData (as needed by TrustKit)
     
     // Initialize domain registry library
     InitializeDomainRegistry();

--- a/TrustKit/public/TSKPinningValidator.h
+++ b/TrustKit/public/TSKPinningValidator.h
@@ -1,5 +1,5 @@
 /*
- 
+
  TSKPinningValidator.h
  TrustKit
  
@@ -10,6 +10,7 @@
  */
 
 #import "TSKTrustDecision.h"
+#import "TSKPinningValidatorCallback.h"
 
 #if __has_feature(modules)
 @import Foundation;
@@ -35,6 +36,36 @@
  For these connections, pin validation must be manually triggered using one of the two available methods within `TSKPinningValidator`.
  */
 @interface TSKPinningValidator : NSObject
+
+#pragma mark Properties
+
+/**
+ The dictionary of domains that were configured and their corresponding pinning policy.
+ */
+@property (nonatomic, readonly, nonnull) NSDictionary<NSString *, TKSDomainPinningPolicy *> *domainPinningPolicies;
+
+/**
+ Set to true to ignore the trust anchors in the user trust store. Only applicable
+ to platforms that support a user trust store (Mac OS).
+ */
+@property (nonatomic, readonly) BOOL ignorePinsForUserTrustAnchors;
+
+/**
+ The callback invoked with validation results.
+ */
+@property (nonatomic, nullable) TSKPinningValidatorCallback validationCallback;
+
+#pragma mark Init routine
+
+/**
+ Initialize an instance of TSKPinningValidator.
+
+ @param domainPinningPolicies A dictionary of domains and the corresponding pinning policy.
+ @param ignorePinsForUserTrustAnchors Set to true to ignore the trust anchors in the user trust store
+ @return Initialized instance
+ */
+- (instancetype _Nullable)initWithDomainPinningPolicies:(NSDictionary<NSString *, NSDictionary *> * _Nonnull)domainPinningPolicies
+                          ignorePinsForUserTrustAnchors:(BOOL)ignorePinsForUserTrustAnchors;
 
 #pragma mark High-level Validation Method
 
@@ -70,7 +101,6 @@
       completionHandler:(void (^ _Nonnull)(NSURLSessionAuthChallengeDisposition disposition,
                                            NSURLCredential * _Nullable credential))completionHandler;
 
-
 #pragma mark Low-level Validation Method
 
 /**
@@ -90,8 +120,7 @@
  
  @exception NSException Thrown when TrustKit has not been initialized with a pinning policy.
  */
-- (TSKTrustDecision)evaluateTrust:(SecTrustRef _Nonnull)serverTrust forHostname:(NSString * _Nonnull)serverHostname;
-
-
+- (TSKTrustDecision)evaluateTrust:(SecTrustRef _Nonnull)serverTrust
+                      forHostname:(NSString * _Nonnull)serverHostname;
 
 @end

--- a/TrustKit/public/TrustKit.h
+++ b/TrustKit/public/TrustKit.h
@@ -203,6 +203,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConfiguration:(NSDictionary<TSKGlobalConfigurationKey, id> *)trustKitConfig
             sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 
+#pragma mark TLS Validation Reports
+
+/** 
+ Receives pin validation results and turns them into pin validation reports
+
+ This is called by the default TSKPinningValidator implementation. If you are subclassing the default
+ implementation, you should call this function in your TSKPinningValidatorCallback to send reports of
+ validation errors.
+
+ @param result The TSKPinningValidatorResult resulting from the validation of the server’s identity.
+ @param notedHostname The entry within the SSL pinning configuration that was used for the server being validated.
+ @param notedHostnamePinningPolicy The notedHostname‘s pinning policy, which was used for the server being validated.
+ */
+- (void)sendValidationReport:(TSKPinningValidatorResult *)result
+               notedHostname:(NSString *)notedHostname 
+               pinningPolicy:(NSDictionary<TSKDomainConfigurationKey, id> *)notedHostnamePinningPolicy;
 
 #pragma mark Other Settings
 


### PR DESCRIPTION
This allows for easier subclassing of the implementation, since from Swift the only init routine available doesn't pass the pinned domain config, resulting in the `super` class claiming that no domains are pinned.